### PR TITLE
Work around bugs in IE and Edge's Range.toString() implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import createNodeIterator from 'dom-node-iterator'
 import seek from 'dom-seek'
 
-const SHOW_TEXT = 4
+import rangeToString from './range-to-string'
 
+const SHOW_TEXT = 4
 
 export function fromRange(root, range) {
   if (root === undefined) {
@@ -21,8 +22,8 @@ export function fromRange(root, range) {
   prefix.setStart(root, 0)
   prefix.setEnd(startNode, startOffset)
 
-  let start = prefix.toString().length
-  let end = start + range.toString().length
+  let start = rangeToString(prefix).length
+  let end = start + rangeToString(range).length
 
   return {
     start: start,

--- a/src/range-to-string.js
+++ b/src/range-to-string.js
@@ -6,17 +6,17 @@
 function nextNode(node, skipChildren) {
   if (!skipChildren && node.firstChild) {
     return node.firstChild
-  } else if (node.nextSibling) {
-    return node.nextSibling
   }
-  while (node.parentNode) {
-    node = node.parentNode
+
+  do {
     if (node.nextSibling) {
       return node.nextSibling
     }
-  }
+    node = node.parentNode
+  } while (node)
+
   /* istanbul ignore next */
-  return null
+  return node
 }
 
 function firstNode(range) {

--- a/src/range-to-string.js
+++ b/src/range-to-string.js
@@ -1,0 +1,68 @@
+/* global Node */
+
+/**
+ * Return the next node after `node` in a tree order traversal of the document.
+ */
+function nextNode(node, skipChildren) {
+  if (!skipChildren && node.firstChild) {
+    return node.firstChild
+  } else if (node.nextSibling) {
+    return node.nextSibling
+  }
+  while (node.parentNode) {
+    node = node.parentNode
+    if (node.nextSibling) {
+      return node.nextSibling
+    }
+  }
+  /* istanbul ignore next */
+  return null
+}
+
+function firstNode(range) {
+  if (range.startContainer.nodeType === Node.ELEMENT_NODE) {
+    const node = range.startContainer.childNodes[range.startOffset]
+    return node || range.startContainer
+  }
+  return range.startContainer
+}
+
+function firstNodeAfter(range) {
+  if (range.endContainer.nodeType === Node.ELEMENT_NODE) {
+    const node = range.endContainer.childNodes[range.endOffset]
+    return node || nextNode(range.endContainer, true /* skip children */)
+  }
+  return nextNode(range.endContainer)
+}
+
+function forEachNodeInRange(range, cb) {
+  let node = firstNode(range)
+  const pastEnd = firstNodeAfter(range)
+  while (node !== pastEnd) {
+    cb(node)
+    node = nextNode(node)
+  }
+}
+
+/**
+ * A ponyfill for Range.toString().
+ * Spec: https://dom.spec.whatwg.org/#dom-range-stringifier
+ *
+ * Works around the buggy Range.toString() implementation in IE and Edge.
+ * See https://github.com/tilgovi/dom-anchor-text-position/issues/4
+ */
+export default function rangeToString(range) {
+  // This is a fairly direct translation of the Range.toString() implementation
+  // in Blink.
+  let text = ''
+  forEachNodeInRange(range, (node) => {
+    if (node.nodeType !== Node.TEXT_NODE) {
+      return
+    }
+    const start = node === range.startContainer ? range.startOffset : 0
+    const end = node === range.endContainer ? range.endOffset : node.textContent.length
+    text += node.textContent.slice(start, end)
+  })
+  return text
+}
+

--- a/src/range-to-string.js
+++ b/src/range-to-string.js
@@ -22,7 +22,7 @@ function nextNode(node, skipChildren) {
 function firstNode(range) {
   if (range.startContainer.nodeType === Node.ELEMENT_NODE) {
     const node = range.startContainer.childNodes[range.startOffset]
-    return node || range.startContainer
+    return node || nextNode(range.startContainer, true /* skip children */)
   }
   return range.startContainer
 }

--- a/test/fixtures/test.html
+++ b/test/fixtures/test.html
@@ -7,3 +7,6 @@
   wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum
   orci, sagittis tempus lacus enim ac dui. <a href="#">Donec non enim</a> in
   turpis pulvinar facilisis. Ut felis.</p>
+<hr>
+<p>Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue,
+   eu vulputate magna eros eu erat.</p>

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -131,6 +131,29 @@ describe('textPosition', () => {
       ].join('')
       assert.equal(text, expected)
     })
+
+    it('can describe a range starting at an empty element', () => {
+      let root = fixture.el
+      let range = document.createRange()
+      let hrEl = root.querySelector('hr')
+      range.setStart(hrEl, 0)
+      range.setEnd(hrEl.nextSibling.firstChild, 16)
+      let {start, end} = fromRange(root, range)
+      let text = root.textContent.substr(start, end - start)
+      assert.equal(text, 'Praesent dapibus')
+    });
+
+    it('can describe a range ending at an empty element', () => {
+      let root = fixture.el
+      let range = document.createRange()
+      let hrEl = root.querySelector('hr')
+      let prevText = hrEl.previousSibling.lastChild
+      range.setStart(prevText, prevText.textContent.length - 9)
+      range.setEnd(hrEl, 0)
+      let {start, end} = fromRange(root, range)
+      let text = root.textContent.substr(start, end - start)
+      assert.equal(text, 'Ut felis.')
+    });
   })
 
   describe('toRange', () => {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -154,6 +154,28 @@ describe('textPosition', () => {
       let text = root.textContent.substr(start, end - start)
       assert.equal(text, 'Ut felis.')
     });
+
+    it('can describe a range beginning at the end of a non-empty element', () => {
+      let root = fixture.el
+      let range = document.createRange()
+      let strongEl = root.querySelector('strong')
+      range.setStart(strongEl, 1)
+      range.setEnd(strongEl.nextSibling, 9)
+      let {start, end} = fromRange(root, range)
+      let text = root.textContent.substr(start, end - start)
+      assert.equal(text, ' senectus')
+    });
+
+    it('can describe a collapsed range', () => {
+      let root = fixture.el
+      let range = document.createRange()
+      let strongEl = root.querySelector('strong')
+      range.setStart(strongEl.firstChild, 10)
+      range.setEnd(strongEl.firstChild, 5)
+      let {start, end} = fromRange(root, range)
+      let text = root.textContent.substr(start, end - start)
+      assert.equal(text, '')
+    });
   })
 
   describe('toRange', () => {


### PR DESCRIPTION
Work around the issues with IE and Blink's implementation of Range.toString() described in https://github.com/tilgovi/dom-anchor-text-position/issues/4

The workaround uses a ponyfill for Range.toString() based on a fairly
direct translation of Blink's [Range::toString()](https://cs.chromium.org/chromium/src/third_party/WebKit/Source/core/dom/Range.cpp?q=range::tostring&sq=package:chromium&l=933) logic.

Tested with the existing tests for this package, plus those from the Hypothesis client. I also compared the output of the native implementation of Range.toString() and the ponyfill on the HTML single-page spec.

The native implementation of Range.toString() is several times faster (60-120ms on https://html.spec.whatwg.org/ vs. ~400ms for the ponyfill), so if we're happy with the approach here, I can follow it up with logic to use the native version if it doesn't have the bugs that IE/Edge's one has.

Fixes #4 