### PR TITLE
Handle start/end positions equal to the root's text content length

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ the text content of the `root` `Node`.
 
 If the end is not provided, returns a collapsed range. If the start is not
 provided, the default is `0`.
+
+If the `start` or `end` offsets are outside the range of valid character offsets
+within the text content of the `root` node, an exception is thrown.

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/tilgovi/dom-anchor-text-position",
   "dependencies": {
-    "dom-node-iterator": "^3.5.0",
-    "dom-seek": "^4.0.1"
+    "dom-node-iterator": "^3.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export function toRange(root, selector = {}) {
 
   // Iterate over text nodes and find where the start and end positions occur.
   let iter = createNodeIterator(root, SHOW_TEXT)
-  while (iter.nextNode()) {
+  while (iter.nextNode() && (startContainer === null || endContainer === null)) {
     let nodeTextLength = iter.referenceNode.nodeValue.length
 
     if (startContainer === null &&

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -267,6 +267,9 @@ describe('textPosition', () => {
 
     it('handles an empty root element', () => {
       let root = document.createElement('div');
+
+      // This case throws to preserve the invariant that the returned `Range`
+      // always has a text node as the `startContainer` and `endContainer`.
       assert.throws(() => {
         toRange(root, {start:0, end: 0})
       }, 'Start offset of position selector is out of range');

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -278,5 +278,19 @@ describe('textPosition', () => {
       let range = toRange(root, {start:0, end: 0})
       assert.equal(range.toString(), '')
     })
+
+    it('handles an `end` offset less than the `start` offset', () => {
+      let root = fixture.el
+      let expected = 'do vit'
+      let start = root.textContent.indexOf(expected)
+      let end = start + expected.length
+      let range = toRange(root, {start: end, end: start})
+      let text = range.toString()
+
+      // This case could reasonably throw or simply return a collapsed range.
+      // It returns a collapsed range as that seems like it would be more
+      // convenient for the caller.
+      assert.equal(text, '')
+    })
   })
 })

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -254,5 +254,19 @@ describe('textPosition', () => {
         toRange(root, {start, end})
       }, 'End offset of position selector is out of range')
     })
+
+    it('handles an empty root element', () => {
+      let root = document.createElement('div');
+      assert.throws(() => {
+        toRange(root, {start:0, end: 0})
+      }, 'Start offset of position selector is out of range');
+    })
+
+    it('handles a root element with an empty text node', () => {
+      let root = document.createElement('div');
+      root.appendChild(document.createTextNode())
+      let range = toRange(root, {start:0, end: 0})
+      assert.equal(range.toString(), '')
+    })
   })
 })

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -274,7 +274,7 @@ describe('textPosition', () => {
 
     it('handles a root element with an empty text node', () => {
       let root = document.createElement('div');
-      root.appendChild(document.createTextNode())
+      root.appendChild(document.createTextNode(''))
       let range = toRange(root, {start:0, end: 0})
       assert.equal(range.toString(), '')
     })

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -218,5 +218,41 @@ describe('textPosition', () => {
       let range = toRange(fixture.el)
       assert.isTrue(range.collapsed)
     })
+
+    it('returns a range selecting the last text of the root element', () => {
+      let root = fixture.el
+      let expected = 'erat.'
+      let end = root.textContent.length
+      let start = end - 5
+      let range = toRange(root, {start, end})
+      let text = range.toString()
+      assert.equal(text, expected)
+    })
+
+    it('returns an empty range selecting the end of the root element', () => {
+      let root = fixture.el
+      let end = root.textContent.length
+      let range = toRange(root, {start: end, end})
+      let text = range.toString()
+      assert.equal(text, '')
+    })
+
+    it('throws an error if the start offset is out of range', () => {
+      let root = fixture.el
+      assert.throws(() => {
+        let start = 10000
+        let end = start + 1
+        toRange(root, {start, end})
+      }, 'Start offset of position selector is out of range')
+    })
+
+    it('throws an error if the end offset is out of range', () => {
+      let root = fixture.el
+      assert.throws(() => {
+        let start = 0
+        let end = 10000
+        toRange(root, {start, end})
+      }, 'End offset of position selector is out of range')
+    })
   })
 })

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -219,6 +219,16 @@ describe('textPosition', () => {
       assert.isTrue(range.collapsed)
     })
 
+    it('returns a range selecting the first text of the root element', () => {
+      let root = fixture.el
+      let expected = 'Pellentesque'
+      let start = 0
+      let end = expected.length
+      let range = toRange(root, {start, end})
+      let text = range.toString()
+      assert.equal(text, expected)
+    })
+
     it('returns a range selecting the last text of the root element', () => {
       let root = fixture.el
       let expected = 'erat.'


### PR DESCRIPTION
Re-implement the `toRange` function to better handle cases where:

- The start or end positions include the end of the root element's text
- The start or end positions are outside the range `[0, root.textContent.length]`
- The root node is empty or consists of just an empty text node

This fixes an issue encountered in Hypothesis' PDF annotation where
creating an annotation would fail if the selection included the last
character of a PDF page's text layer ([original bug report](https://github.com/hypothesis/client/issues/1329)).

This implementation also makes it more obvious which of the two possible
range configurations is used when the `start` or `end` offset occurs at
a text node boundary. In that case, the range could use either the end
of one text node or the start of the next as the boundary point. The
boundary point is always placed at the end of the earlier node in that case.